### PR TITLE
remove need for sql, too complex permissions

### DIFF
--- a/dbplyr_shamp.Rmd
+++ b/dbplyr_shamp.Rmd
@@ -6,8 +6,7 @@ output:
   prettydoc::html_pretty:
     theme: architect
     highlight: github
-params:
-  pwd: "data607"
+
 ---
 
 ```{r setup, include=FALSE}
@@ -59,7 +58,7 @@ dbSendQuery(conn, "CREATE DATABASE Congress_v_Trump;")
 
 Next, let the server know you intend to use the DB you created. If starting a new session (after creating the data), establish a connection and identify the database name. 
 
-```{r}
+```markdown
 conn <-                                     
     dbConnect(
       MySQL(),
@@ -77,11 +76,14 @@ The data is stored on a `.csv` file and we can load the `.csv` as dataframe and 
 
 **You only need to do this once. The data will stay on your SQL server as long as you want.**
 
-```markdown
+For simplicity, just load the data from csv so that you do not need to actually access a SQL server. 
+
+```{r}
 m<-getURL(
 "https://raw.githubusercontent.com/Shampjeff/cuny_msds/master/DATA_607/data/averages.csv")
 df<-read.csv(text=m, header = T, stringsAsFactors = F)
-dbWriteTable(conn = conn, name = "Congress_v_Trump", value = df)
+# If you wanted to write to a database for the first time, this is code to do that. 
+# dbWriteTable(conn = conn, name = "Congress_v_Trump", value = df)
 ```
 
 This data is now on our SQL server and ready to be used. 
@@ -98,7 +100,8 @@ First, you need to let dbplyr know that you are using a database by pointing to 
 **If you use a html display for your data (DT in this case), you'll have to cast the variable assigned to `tbl()` explicitly with `as.data.frame()`**
 
 ```{r}
-df<-tbl(conn, "Congress_v_Trump")
+# code for table reference
+# df<-tbl(conn, "Congress_v_Trump")
 
 DT::datatable(as.data.frame(df),
          extensions = c('FixedColumns',"FixedHeader"),


### PR DESCRIPTION
Removing all need for SQL, the permissions are too complex for this assignment. Steps for using sql are shown, but the data is loaded from csv so that anyone can run this file without needing permission on the cloud. 